### PR TITLE
Update build configuration for Gradle 8 and Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add to _build.gradle_:
 
 `compile 'com.github.barteksc:android-pdf-viewer:2.8.2'`
 
-Library is available in jcenter repository, probably it'll be in Maven Central soon.
+Library is available in Maven Central repository.
 
 ## Include PDFView in your layout
 

--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -1,29 +1,5 @@
 apply plugin: 'com.android.library'
 
-ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'android-pdf-viewer'
-
-    publishedGroupId = 'com.github.barteksc'
-    libraryName = 'AndroidPdfViewer'
-    artifact = 'android-pdf-viewer'
-
-    libraryDescription = 'Android view for displaying PDFs rendered with PdfiumAndroid'
-
-    siteUrl = 'https://github.com/barteksc/AndroidPdfViewer'
-    gitUrl = 'https://github.com/barteksc/AndroidPdfViewer.git'
-
-    libraryVersion = '2.8.2'
-
-    developerId = 'barteksc'
-    developerName = 'Bartosz Schiller'
-    developerEmail = 'barteksch@boo.pl'
-
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ["Apache-2.0"]
-}
-
 android {
     compileSdkVersion 25
     buildToolsVersion '25.0.3'
@@ -40,6 +16,3 @@ android {
 dependencies {
     compile 'com.github.barteksc:pdfium-android:1.7.1'
 }
-
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,15 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.android.tools.build:gradle:8.2.2'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         // replace with the current version of the android-apt plugin
@@ -9,7 +9,7 @@ buildscript {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
## Summary
- replace deprecated jcenter repositories with mavenCentral and upgrade to AGP 8.2.2
- remove legacy Bintray publishing scripts and plugins
- update Gradle wrapper to 8.5 and refresh README

## Testing
- `./gradlew --version` *(failed: Unable to tunnel through proxy, 403)*
- `gradle tasks` *(failed: Could not resolve com.android.tools.build:gradle:8.2.2, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68962f52298c832bb8d052e0eb31e2e6