### PR TITLE
chore: migrate to AndroidX and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ currently `OnPageErrorListener` set with `Configurator#onPageError()` is called.
 
 Add to _build.gradle_:
 
-`compile 'com.github.barteksc:android-pdf-viewer:2.8.2'`
+`implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'`
 
 Library is available in Maven Central repository.
 

--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -1,18 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    namespace 'com.github.barteksc.pdfviewer'
+    compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 34
         versionCode 1
         versionName "2.8.2"
     }
-
 }
 
 dependencies {
-    compile 'com.github.barteksc:pdfium-android:1.7.1'
+    implementation 'com.github.barteksc:pdfium-android:1.9.0'
 }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/CacheManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/CacheManager.java
@@ -16,7 +16,7 @@
 package com.github.barteksc.pdfviewer;
 
 import android.graphics.RectF;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.github.barteksc.pdfviewer.model.PagePart;
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.ViewGroup;

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
     dependencies {
@@ -10,6 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenCentral()
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,36 +1,20 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        // replace with the current version of the android-apt plugin
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    }
-}
-
-repositories {
-    mavenCentral()
-}
-
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    namespace 'com.github.barteksc.sample'
+    compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 34
         versionCode 3
         versionName "2.0.0"
     }
-
 }
 
 dependencies {
-    compile project(':android-pdf-viewer')
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    provided 'org.androidannotations:androidannotations:4.0.0'
-    compile 'org.androidannotations:androidannotations-api:4.0.0'
+    implementation project(':android-pdf-viewer')
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'org.androidannotations:androidannotations-api:4.8.0'
+    annotationProcessor 'org.androidannotations:androidannotations:4.8.0'
 }

--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -22,10 +22,10 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.net.Uri;
 import android.provider.OpenableColumns;
-import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Toast;
 


### PR DESCRIPTION
## Summary
- upgrade library and sample modules to SDK 34
- replace deprecated support libraries with AndroidX
- switch to implementation dependencies and update pdfium-android

## Testing
- `./gradlew build` *(fails: Could not resolve com.android.tools.build:gradle:8.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_689632331e78832bb61512839e28a8b4